### PR TITLE
Add conditional check when cors.allowOrigin is *

### DIFF
--- a/src/JDesrosiers/Silex/Provider/CorsServiceProvider.php
+++ b/src/JDesrosiers/Silex/Provider/CorsServiceProvider.php
@@ -98,6 +98,10 @@ class CorsServiceProvider implements ServiceProviderInterface, BootableProviderI
                     $response->headers->set("Access-Control-Expose-Headers", $app["cors.exposeHeaders"]);
                 }
 
+                if($app["cors.allowOrigin"] === '*') {
+                    $app["cors.allowOrigin"] = null;
+                }
+
                 $origin = $request->headers->get("Origin");
                 if (is_null($app["cors.allowOrigin"])) {
                     $app["cors.allowOrigin"] = $origin;

--- a/tests/JDesrosiers/Tests/Silex/Provider/CorsServiceProviderTest.php
+++ b/tests/JDesrosiers/Tests/Silex/Provider/CorsServiceProviderTest.php
@@ -197,6 +197,27 @@ class CorsServiceProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("", $response->getContent());
     }
 
+    public function testAllowOriginWildcard()
+    {
+        $this->app["cors.allowOrigin"] = "*";
+
+        $this->app->get("/foo", function () {
+            return "foo";
+        });
+
+        $headers = array(
+            "HTTP_ORIGIN" => "www.foo.com",
+            "HTTP_ACCESS_CONTROL_REQUEST_METHOD" => "GET",
+        );
+        $client = new Client($this->app, $headers);
+        $client->request("OPTIONS", "/foo");
+
+        $response = $client->getResponse();
+
+        $this->assertEquals("204", $response->getStatusCode());
+        $this->assertEquals($headers["HTTP_ORIGIN"], $response->headers->get("Access-Control-Allow-Origin"));
+    }
+
     public function testAllowMethods()
     {
         $this->app["cors.allowMethods"] = "GET";


### PR DESCRIPTION
When `cors.allowOrigin` is set to `*` (any) it currently defaults to `null` -- this fixes that.
