### PR TITLE
Explicitly remove _method from requirements

### DIFF
--- a/src/CorsServiceProvider.php
+++ b/src/CorsServiceProvider.php
@@ -57,6 +57,10 @@ class CorsServiceProvider implements ServiceProviderInterface
     private function createOptionsRoutes(Application $app, $allow)
     {
         foreach ($allow as $path => $routeDetails) {
+            // Remove _method from requirements, it would cause a
+            // E_USER_DEPRECATED error with Symfony Routing component 2.7+
+            unset($routeDetails['requirements']['_method']);
+
             $app->match($path, new OptionsController($routeDetails["methods"]))
                 ->setRequirements($routeDetails["requirements"])
                 ->method("OPTIONS");


### PR DESCRIPTION
To avoid getting E_USER_DEPRECATED warnings with Symfony Routing 2.7+, remove _method from the requirements copied over from the original route(s). It wasn't used anyway, as the required method was already explicitly set to OPTIONS with a call to method('OPTIONS').