### PR TITLE
Fix multiple allowed CORS methods in Internet Explorer Edge

### DIFF
--- a/src/Cors.php
+++ b/src/Cors.php
@@ -36,7 +36,7 @@ class Cors
 
             // TODO: Allow cors.allowHeaders to be set and use it to validate the request
             $headers["Access-Control-Allow-Headers"] = $request->headers->get("Access-Control-Request-Headers");
-            $headers["Access-Control-Allow-Methods"] = $allowedMethods;
+            $headers["Access-Control-Allow-Methods"] = implode(' ,', $allowedMethods);
             $headers["Access-Control-Max-Age"] = $this->app["cors.maxAge"];
         } else {
             $headers["Access-Control-Expose-Headers"] = $this->app["cors.exposeHeaders"];

--- a/src/Cors.php
+++ b/src/Cors.php
@@ -36,7 +36,7 @@ class Cors
 
             // TODO: Allow cors.allowHeaders to be set and use it to validate the request
             $headers["Access-Control-Allow-Headers"] = $request->headers->get("Access-Control-Request-Headers");
-            $headers["Access-Control-Allow-Methods"] = implode(' ,', $allowedMethods);
+            $headers["Access-Control-Allow-Methods"] = implode(',', $allowedMethods);
             $headers["Access-Control-Max-Age"] = $this->app["cors.maxAge"];
         } else {
             $headers["Access-Control-Expose-Headers"] = $this->app["cors.exposeHeaders"];

--- a/src/CorsServiceProvider.php
+++ b/src/CorsServiceProvider.php
@@ -57,6 +57,10 @@ class CorsServiceProvider implements ServiceProviderInterface
     private function createOptionsRoutes(Application $app, $allow)
     {
         foreach ($allow as $path => $routeDetails) {
+            // Remove _method from requirements, it would cause a
+            // E_USER_DEPRECATED error with Symfony Routing component 2.7+
+            unset($routeDetails['requirements']['_method']);
+
             $app->match($path, new OptionsController($routeDetails["methods"]))
                 ->setRequirements($routeDetails["requirements"])
                 ->method("OPTIONS");


### PR DESCRIPTION
Internet Explorer Edge does not like multiple Access-Control-Allow-Methods headers, instead put all values in a comma separated list in one header.