### PR TITLE
Update OptionsController.php

### DIFF
--- a/src/OptionsController.php
+++ b/src/OptionsController.php
@@ -15,6 +15,6 @@ class OptionsController
 
     public function __invoke()
     {
-        return Response::create("", 204, array("Allow" => implode(",", $this->methods)));
+        return Response::create("", 204, array("Access-Control-Allow-Methods" => implode(",", $this->methods), "Allow" => implode(",", $this->methods)));
     }
 }


### PR DESCRIPTION
I experienced some issues in swagger when only sticking ot the "Allow" header, swagger (in firefox) misses the header named "Access-Control-Allow-Methods" with the allowed request types. Thus I used the same values as for the "Allow" header and added to "Access-Control-Allow-Methods".
According to RFC it seems there actually is no header called "Allow" but only "Access-Control-Allow-Methods" (https://www.w3.org/TR/cors/#access-control-allow-methods-response-header)