### PR TITLE
CORS default shouldn't be null

### DIFF
--- a/src/Cors.php
+++ b/src/Cors.php
@@ -55,7 +55,13 @@ class Cors
             $headers["Access-Control-Expose-Headers"] = $options["exposeHeaders"];
         }
 
-        $headers["Access-Control-Allow-Origin"] = $this->allowOrigin($request, $options["allowOrigin"]);
+        $allowOrigin = $this->allowOrigin($request, $options["allowOrigin"]);
+
+        if (!$allowOrigin) {
+            return [];
+        }
+
+        $headers["Access-Control-Allow-Origin"] = $allowOrigin;
         $headers["Access-Control-Allow-Credentials"] = $this->allowCredentials($options["allowCredentials"]);
 
         $response->headers->add(array_filter($headers));
@@ -102,7 +108,7 @@ class Cors
             }
         }
 
-        return "null";
+        return false;
     }
 
     private function domainToRegex($domain)

--- a/src/Test/CorsServiceProviderTest.php
+++ b/src/Test/CorsServiceProviderTest.php
@@ -138,10 +138,10 @@ class CorsServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals("204", $response->getStatusCode());
         $this->assertEquals("GET", $response->headers->get("Allow"));
-        $this->assertEquals("GET", $response->headers->get("Access-Control-Allow-Methods"));
-        $this->assertEquals("null", $response->headers->get("Access-Control-Allow-Origin"));
+        $this->assertFalse($response->headers->has("Access-Control-Allow-Methods"));
+        $this->assertFalse($response->headers->has("Access-Control-Allow-Origin"));
         $this->assertFalse($response->headers->has("Access-Control-Allow-Headers"));
-        $this->assertEquals("15", $response->headers->get("Access-Control-Max-Age"));
+        $this->assertFalse($response->headers->has("Access-Control-Max-Age"));
         $this->assertFalse($response->headers->has("Access-Control-Allow-Credentials"));
         $this->assertFalse($response->headers->has("Access-Control-Expose-Headers"));
         $this->assertFalse($response->headers->has("Content-Type"));


### PR DESCRIPTION
I know this has been brought up here:
https://github.com/jdesrosiers/silex-cors-provider/issues/25

But really "null" should not be the default where there's no origin match. Its use is now discouraged.

Here's some more info:
https://w3c.github.io/webappsec-cors-for-developers/#avoid-returning-access-control-allow-origin-null
https://web-in-security.blogspot.de/2017/07/cors-misconfigurations-on-large-scale.html
http://blog.portswigger.net/2016/10/exploiting-cors-misconfigurations-for.html
https://www.youtube.com/watch?v=wgkj4ZgxI4c


