### PR TITLE
add message to NotFoundHttpException

### DIFF
--- a/src/CorsServiceProvider.php
+++ b/src/CorsServiceProvider.php
@@ -31,7 +31,7 @@ class CorsServiceProvider implements ServiceProviderInterface, BootableProviderI
         $app->on(KernelEvents::EXCEPTION, function (GetResponseForExceptionEvent $event) {
             $e = $event->getException();
             if ($e instanceof MethodNotAllowedHttpException && $e->getHeaders()["Allow"] === "OPTIONS") {
-                $event->setException(new NotFoundHttpException());
+                $event->setException(new NotFoundHttpException("No route found for \"{$event->getRequest()->getMethod()} {$event->getRequest()->getPathInfo()}\""));
             }
         });
     }


### PR DESCRIPTION
Hi,

I came across this situation that could create a bit of confusion - the 404 (NotFoundHttpException) is triggered without a message. 
I think the proper message would be that there is no route defined for that path, so if you agree that returning a message is useful in this situation, you could include this in the main build.

Regards
Adrian