### PR TITLE
Fix composer deprecation notice

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require-dev": {
         "symfony/browser-kit": "2.3.*",
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "5.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,11 @@
             "JDesrosiers\\Silex\\Provider\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "JDesrosiers\\Silex\\Provider\\Tests\\": "tests/"
+        }
+    },
     "scripts": {
         "test": "vendor/bin/phpunit --colors"
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,15 +11,12 @@
 >
     <testsuites>
         <testsuite name="silex-cors-provider Test Suite">
-            <directory>src/Test</directory>
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
     <filter>
         <whitelist>
             <directory>src</directory>
-            <exclude>
-                <directory>src/Test</directory>
-            </exclude>
         </whitelist>
     </filter>
 </phpunit>

--- a/tests/CorsEnableApplicationTest.php
+++ b/tests/CorsEnableApplicationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace JDesrosiers\Silex\Provider\Test;
+namespace JDesrosiers\Silex\Provider\Tests;
 
 use JDesrosiers\Silex\Provider\CorsServiceProvider;
 use Silex\Application;

--- a/tests/CorsEnableControlerTest.php
+++ b/tests/CorsEnableControlerTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace JDesrosiers\Silex\Provider\Test;
+namespace JDesrosiers\Silex\Provider\Tests;
 
 use JDesrosiers\Silex\Provider\CorsServiceProvider;
 use Silex\Application;
 use Symfony\Component\HttpKernel\Client;
 
-class CorsEnableControllerCollectionTest extends \PHPUnit_Framework_TestCase
+class CorsEnableControllerTest extends \PHPUnit_Framework_TestCase
 {
     protected $client;
 
@@ -16,11 +16,10 @@ class CorsEnableControllerCollectionTest extends \PHPUnit_Framework_TestCase
         $app["debug"] = true;
         $app->register(new CorsServiceProvider());
 
-        $controllers = $app["controllers_factory"];
-        $controllers->get("/", function () {
+        $controller = $app->get("/foo", function () {
             return "foo";
         });
-        $app->mount("/foo", $app["cors-enabled"]($controllers));
+        $app["cors-enabled"]($controller);
 
         $app->get("/bar", function () {
             return "bar";
@@ -31,7 +30,7 @@ class CorsEnableControllerCollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testEnabledPreflight()
     {
-        $this->client->request("OPTIONS", "/foo/");
+        $this->client->request("OPTIONS", "/foo");
         $response = $this->client->getResponse();
 
         $this->assertTrue($response->isEmpty());
@@ -48,7 +47,7 @@ class CorsEnableControllerCollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testEnabledController()
     {
-        $this->client->request("GET", "/foo/");
+        $this->client->request("GET", "/foo");
         $response = $this->client->getResponse();
 
         $this->assertTrue($response->isOk());

--- a/tests/CorsEnableControllerCollectionTest.php
+++ b/tests/CorsEnableControllerCollectionTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace JDesrosiers\Silex\Provider\Test;
+namespace JDesrosiers\Silex\Provider\Tests;
 
 use JDesrosiers\Silex\Provider\CorsServiceProvider;
 use Silex\Application;
 use Symfony\Component\HttpKernel\Client;
 
-class CorsEnableControllerTest extends \PHPUnit_Framework_TestCase
+class CorsEnableControllerCollectionTest extends \PHPUnit_Framework_TestCase
 {
     protected $client;
 
@@ -16,10 +16,11 @@ class CorsEnableControllerTest extends \PHPUnit_Framework_TestCase
         $app["debug"] = true;
         $app->register(new CorsServiceProvider());
 
-        $controller = $app->get("/foo", function () {
+        $controllers = $app["controllers_factory"];
+        $controllers->get("/", function () {
             return "foo";
         });
-        $app["cors-enabled"]($controller);
+        $app->mount("/foo", $app["cors-enabled"]($controllers));
 
         $app->get("/bar", function () {
             return "bar";
@@ -30,7 +31,7 @@ class CorsEnableControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testEnabledPreflight()
     {
-        $this->client->request("OPTIONS", "/foo");
+        $this->client->request("OPTIONS", "/foo/");
         $response = $this->client->getResponse();
 
         $this->assertTrue($response->isEmpty());
@@ -47,7 +48,7 @@ class CorsEnableControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testEnabledController()
     {
-        $this->client->request("GET", "/foo");
+        $this->client->request("GET", "/foo/");
         $response = $this->client->getResponse();
 
         $this->assertTrue($response->isOk());

--- a/tests/CorsServiceProviderTest.php
+++ b/tests/CorsServiceProviderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace JDesrosiers\Silex\Provider\Test;
+namespace JDesrosiers\Silex\Provider\Tests;
 
 use JDesrosiers\Silex\Provider\CorsServiceProvider;
 use Silex\Application;

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace JDesrosiers\Silex\Provider\Test;
+namespace JDesrosiers\Silex\Provider\Tests;
 
 use JDesrosiers\Silex\Provider\CorsServiceProvider;
 use Silex\Application;


### PR DESCRIPTION
Hi @jdesrosiers,

composer now shows deprecation notice when a file does not comply with psr-4 autoloading standard.

The message is:

`Deprecation Notice: Class JDesrosiers\Silex\Provider\Test\CorsEnableControllerTest located in ./vendor/jdesrosiers/silex-cors-provider/src/Test/CorsEnableControlerTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201`

Instead of just fixing the namespace, I have moved the `src/Test/` directory to `tests/` so tests are not loaded when importing from composer.

PHPUnit was also failing:

`Error: Class 'File_Iterator_Facade' not found in vendor/phpunit/phpunit/PHPUnit/Util/Configuration.php on line 813`

due to an old PHPUnit version.

This PR:

- [x] Moves tests to their own directory
- [x] Updates PHPUnit to version 5 because is the last version that supports PHP 5.6